### PR TITLE
Add time comparison methods to override before? and after?

### DIFF
--- a/lib/ozone.rb
+++ b/lib/ozone.rb
@@ -36,17 +36,31 @@ module Ozone
       @time = time
     end
 
+    def <=> (time_with_zone)
+      if after?(time_with_zone)
+        1
+      elsif before?(time_with_zone)
+        -1
+      else
+        0
+      end
+    end
+
     def before?(time_with_zone)
       adjusted_time < time_with_zone
     end
 
     def after?(time_with_zone)
-      !before?(time_with_zone)
+      adjusted_time > time_with_zone
     end
 
     def strftime(format: '%Y-%m-%d %H:%M')
       Formatter.call(time: @time, offset: @offset, observes_dst: @observes_dst, format: format)
     end
+
+    alias_method :<, :before?
+    alias_method :>, :after?
+    alias_method :to_s, :strftime
 
     private
 

--- a/spec/ozone_spec.rb
+++ b/spec/ozone_spec.rb
@@ -106,9 +106,9 @@ module Ozone
             offset: -480,
             observes_dst: true,
           )
-          expect(ozone_time.before?(1.second.since(time_without_dst))).to be_truthy
-          expect(ozone_time.after?(1.second.since(time_without_dst))).to be_falsey
-          expect(ozone_time.before?(1.second.until(time_without_dst))).to be_falsey
+          expect(ozone_time < (1.second.since(time_without_dst))).to be_truthy
+          expect(ozone_time > (1.second.since(time_without_dst))).to be_falsey
+          expect(ozone_time < (1.second.until(time_without_dst))).to be_falsey
         end
 
         it 'converts a utc time to time with time zone and makes no dst adjustment' do
@@ -117,9 +117,9 @@ module Ozone
             offset: -480,
             observes_dst: false,
           )
-          expect(ozone_time.before?(1.second.since(time_without_dst))).to be_truthy
-          expect(ozone_time.after?(1.second.since(time_without_dst))).to be_falsey
-          expect(ozone_time.before?(1.second.until(time_without_dst))).to be_falsey
+          expect(ozone_time < (1.second.since(time_without_dst))).to be_truthy
+          expect(ozone_time > (1.second.since(time_without_dst))).to be_falsey
+          expect(ozone_time < (1.second.until(time_without_dst))).to be_falsey
         end
       end
 
@@ -132,8 +132,8 @@ module Ozone
             offset: -480,
             observes_dst: true,
           )
-          expect(ozone_time.before?(1.second.since(time_with_dst))).to be_truthy
-          expect(ozone_time.before?(1.second.until(time_with_dst))).to be_falsey
+          expect(ozone_time < (1.second.since(time_with_dst))).to be_truthy
+          expect(ozone_time < (1.second.until(time_with_dst))).to be_falsey
         end
 
         it 'converts a utc time to time with time zone and moves clocks back an hour' do
@@ -143,8 +143,63 @@ module Ozone
             observes_dst: false,
           )
 
-          expect(ozone_time.before?(1.second.since(time_with_dst))).to be_truthy
-          expect(ozone_time.before?(1.second.until(time_with_dst))).to be_truthy
+          expect(ozone_time < (1.second.since(time_with_dst))).to be_truthy
+          expect(ozone_time < (1.second.until(time_with_dst))).to be_truthy
+        end
+      end
+    end
+
+    describe '#<=>' do
+      context  'time outside daylight savings' do
+        let(:time_without_dst) { ::Time.parse("2014-03-09 09:59:00 UTC") }
+
+        it 'compares true o time with time zone and makes no dst adustment' do
+          ozone_time = Time.new(
+              time: time_without_dst,
+              offset: -480,
+              observes_dst: true,
+          )
+          expect(ozone_time <=> (1.second.since(time_without_dst))).to eq (-1)
+          expect(ozone_time <=> (1.second.until(time_without_dst))).to eq 1
+          expect(ozone_time <=> time_without_dst).to eq 0
+        end
+
+        it 'converts a utc time to time with time zone and makes no dst adjustment' do
+          ozone_time = Time.new(
+              time: time_without_dst,
+              offset: -480,
+              observes_dst: false,
+          )
+          expect(ozone_time <=> (1.second.until(time_without_dst))).to eq 1
+          expect(ozone_time <=> (1.second.since(time_without_dst))).to eq (-1)
+          expect(ozone_time <=> time_without_dst).to eq 0
+        end
+      end
+
+      context 'time is during daylight savings' do
+        let(:time_with_dst) { ::Time.parse("2014-03-09 10:00:00 UTC") }
+
+        it 'converts a utc time to time with time zone and makes no dst adustment' do
+          ozone_time = Time.new(
+              time: time_with_dst,
+              offset: -480,
+              observes_dst: true,
+          )
+          expect(ozone_time <=> (1.second.until(time_with_dst))).to eq 1
+          expect(ozone_time <=> (1.second.since(time_with_dst))).to eq (-1)
+          expect(ozone_time <=> time_with_dst).to eq 0
+        end
+
+        fit 'converts a utc time to time with time zone and moves clocks back an hour' do
+          ozone_time = Time.new(
+              time: time_with_dst,
+              offset: -480,
+              observes_dst: false,
+          )
+
+          expect(ozone_time <=> (1.hour.until(1.second.until(time_with_dst)))).to eq 1
+          expect(ozone_time <=> (1.hour.until(1.second.since(time_with_dst)))).to eq (-1)
+          expect(ozone_time <=> 1.hour.until(time_with_dst)).to eq 0
         end
       end
     end


### PR DESCRIPTION
To avoid having to rewrite a bunch of code that compares times, implement <, >, and <=>. Note that after? being simply !before? did not work for equal date comparisons so I changed that method to do its own comparison. 