### PR TITLE
Feature/inverse conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 *.gem
 *.rbc
 /.config
@@ -12,6 +11,7 @@
 /.bundle/
 /.yardoc
 /_yardoc/
+/.idea/
 
 ## Specific to RubyMotion:
 .dat*

--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,6 @@
+if defined?(PryByebug)
+  Pry.commands.alias_command 'c', 'continue'
+  Pry.commands.alias_command 's', 'step'
+  Pry.commands.alias_command 'n', 'next'
+  Pry.commands.alias_command 'f', 'finish'
+end

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,107 @@
+# Practice Fusion Rubocop Rules
+AllCops:
+  # Exclude anything that isn't really part of our code.
+  Exclude:
+    - '**/*.gemspec'
+    - '**/Guardfile' # mostly copy/paste
+    - '**/Rakefile'
+    - 'bin/**/*'
+    - 'config/initializers/secret_token.rb' # long tokens
+    - 'db/**/*' # auto-generated
+    - 'spec/rails_helper.rb' # full of solecisms, mostly copy and paste
+    - 'spec/teaspoon_env.rb' # mostly copy and paste
+    - 'spec/vcr_cassettes/**/*'
+    - 'vendor/**/*'
+  DisplayCopNames: true
+  RunRailsCops: true
+  DisplayStyleGuide: true
+
+# This is less volatile if methods change, and there's less busy work lining things up.
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+# Chain methods with trailing dots.
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+# It's not really clearer to replace every if with a return if.
+Style/GuardClause:
+  Enabled: false
+
+# Would enforce do_y if x over if x / do y / end. As with GuardClause above,
+# this enforces code organisation that doesn't necesarily make things clearer.
+IfUnlessModifier:
+  Enabled: false
+
+# Enforce single quotes everywhere except in specs (because there's a lot of
+# human text with apostrophes in spec names, and using double quotes for all
+# of those is more consistent. There shouldn't be much human-readable text in
+# the application code: that is better moved to the locale files.
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+  Exclude:
+    - 'spec/**/*'
+
+# Trailing commas are totally fine.
+Style/TrailingComma:
+  Enabled: false
+
+# Just a preference to use %w[] over %w()
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '[]'
+    '%w': '[]'
+    '%W': '[]'
+
+# We can tolerate a little additional complexity
+# http://c2.com/cgi/wiki?AbcMetric
+Metrics/AbcSize:
+  Max: 24
+  Exclude:
+    - 'spec/**/*'
+
+# We can tolerate a little additional complexity
+# http://c2.com/cgi/wiki?CyclomaticComplexityMetric
+Metrics/CyclomaticComplexity:
+  Max: 8
+  Exclude:
+    - 'spec/**/*'
+
+# We can tolerate a little additional complexity
+# http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Metrics/PerceivedComplexity
+Metrics/PerceivedComplexity:
+  Max: 8
+  Exclude:
+    - 'spec/**/*'
+
+# Allow long lines in specs, as it's almost impossible to fit RSpec's
+# expectations into 80 characters.
+Metrics/LineLength:
+  Max: 120
+  Exclude:
+    - 'spec/**/*'
+
+# Don't worry about long methods in specs.
+Metrics/MethodLength:
+  Max: 20
+  Exclude:
+    - 'spec/**/*'
+
+# Don't worry about long modules in specs.
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*'
+
+# Prefer sensible naming to comments everywhere.
+Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+
+# Would enforce do_y if x over if x / do y / end. As with GuardClause above,
+# this enforces code organisation that doesn't necesarily make things clearer.
+IfUnlessModifier:
+  Enabled: false
+
+# Don't allow assignment in conditionals, ever.
+Lint/AssignmentInCondition:
+  AllowSafeAssignment: false

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # ozone
-Convert time based on offset, with or without dst
-=======
-# Ozone
-
-Given a ruby time, an offset (in minutes), and a boolean whether to observe daylight savings, Ozone provides two things:
-
-1) Convert a ruby time to a string representation, adjusted by offset, and either abiding by or ignoring daylight savings.
-2) Compare with a ruby time to see whether before or after, either abiding by or ignoring daylight savings.
+Time-to-String and String-to-Time operations which operate using time zone offsets (in minutes) and a boolean which indicates whether or not DST is observed.
 
 ## Installation
 
@@ -23,6 +16,29 @@ And then execute:
 Or install it yourself as:
 
     $ gem install ozone
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+1. Fork it ( https://github.com/[my-github-username]/ozone/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request
+
+
+# Ozone::Time
+
+Given a ruby time (UTC), an offset (in minutes), and a boolean whether to observe daylight savings, Ozone::Time provides two things:
+
+1) Convert a ruby time to a string representation, adjusted by offset, and either abiding by or ignoring daylight savings.
+2) Compare with a ruby time to see whether before or after, either abiding by or ignoring daylight savings.
+
 
 ## Usage
 
@@ -59,10 +75,32 @@ ozone_time = Time.new(
 => true
 ```
 
-This is because during daylight savings, times will be adjusted backwards 1 hour if daylight savings
-is not being observed.
+# Ozone::TimeBuilder
 
-Ozone::Formatter has one method -- call -- which takes a time, offset (from utc, in minutes), whether to use daylight savings, and a [time format](http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime). Default format is YYYY-MM-DD HH:MM.
+Given a datetime string, an offset (in minutes), and a boolean whether to observe daylight savings, Ozone::TimeBuilder builds a ruby time object (UTC). The TimeBuilder serves as an inverse to Ozone::Time which given a ruby time, can generate a string representation of that time.
+
+## Usage
+
+`TimeBuilder` accepts four String formats as input to the `from_string` method:
+ - YYYY/MM/DD HH:MM
+ - YYYY/MM/DDTHH:MM
+ - YYYY-MM-DD HH:MM
+ - YYY-MM-DDTHH:MM
+ 
+```ruby
+> builder = Ozone::TimeBuilder.new
+#<Ozone::TimeBuilder:0x007fff4c6e9f30 @observes_dst=nil, @offset=nil, @time_str=nil>
+> time = builder.from_string("2015-11-15 09:00").with_offset(-480).with_dst(false).build
+=> 2015-11-15 08:00:00 UTC
+```
+
+# Ozone::Formatter
+
+Takes a time, offset (from utc, in minutes), whether to use daylight savings, and a [time format](http://ruby-doc.org/core-2.2.0/Time.html#method-i-strftime). Default format is YYYY-MM-DD HH:MM.
+
+## Usage
+Since all operations are executing in UTC time, the time zone in the format string will *always* be UTC. 
+This functionality can also be accessed via the Ozone::Time#strftime method.
 
 ```ruby
 > Ozone::Formatter.call(time: t, offset: -480, observes_dst: true)
@@ -72,20 +110,4 @@ Ozone::Formatter has one method -- call -- which takes a time, offset (from utc,
 => "2014/07/17 16:30"
 ```
 
-This functionality can also be accessed via the Ozone::Time#strftime method.
 
-### NOTE: Since all operations are executing in UTC time, the time zone in the format string will *always* be UTC
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-1. Fork it ( https://github.com/[my-github-username]/ozone/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request

--- a/lib/ozone.rb
+++ b/lib/ozone.rb
@@ -1,5 +1,4 @@
 require 'ozone/version'
-
 require 'active_support/time'
 
 module Ozone
@@ -18,8 +17,8 @@ module Ozone
       @time = time
     end
 
-    def <=>(time_with_zone)
-      adjusted_time <=> to_ozone_time(time_with_zone).adjusted_time
+    def <=>(other)
+      adjusted_time <=> to_ozone_time(other).adjusted_time
     end
 
     def before?(time_with_zone)

--- a/lib/ozone/version.rb
+++ b/lib/ozone/version.rb
@@ -1,3 +1,3 @@
 module Ozone
-  VERSION = "0.3.0"
+  VERSION = "1.0.0"
 end

--- a/lib/time_builder.rb
+++ b/lib/time_builder.rb
@@ -1,0 +1,80 @@
+require 'ozone/version'
+require 'active_support/time'
+
+module Ozone
+  class TimeBuilder
+    # Valid formats:
+    # YYYY/MM/DD 00:00,YYYY/MM/DDT00:00, YYYY-MM-DD 00:00, YYYY-MM-DDT00:00
+    DATETIME_FORMAT = %r[(\d{4}[/-]\d{2}[/-]\d{2})[ T](\d{2}:\d{2})]
+
+    def from_string(time_str)
+      @time_str = time_str
+      self
+    end
+
+    def with_offset(offset)
+      @offset = offset
+      self
+    end
+
+    def with_dst(observes_dst)
+      @observes_dst = observes_dst
+      self
+    end
+
+    def build
+      fail StandardError, 'from_string() must be supplied a non-nil datetime string' unless @time_str.is_a?(String)
+      fail StandardError, 'from_string() argument should match YYYY/MM/DD HH:MM' unless DATETIME_FORMAT.match(@time_str)
+      fail StandardError, 'with_offset() must be supplied a number' unless @offset.is_a?(Numeric)
+      fail StandardError, 'with_dst() must be supplied a boolean' if @observes_dst.nil?
+      calculate_utc_time
+    end
+
+    private
+
+    PST = ActiveSupport::TimeZone['Pacific Time (US & Canada)']
+
+    def calculate_utc_time
+      date = DATETIME_FORMAT.match(@time_str)[1]
+      time = DATETIME_FORMAT.match(@time_str)[2]
+
+      # Build UTC time and add/subtract minutes to avoid timezone assumptions and automatic conversions
+      # Apply offsets manually based on @offset and whether or not DST is in effect in a zone known to observe
+      # DST during the specified date/time
+      utc = ::Time.parse("#{date}T#{time}+0000").utc
+
+      if during_dst(date, time) && @observes_dst
+        utc -= 60.minutes
+      end
+
+      if @offset > 0
+        utc + @offset.minutes
+      else
+        utc - @offset.minutes
+      end
+    end
+
+    def during_dst(date, time)
+      pst_time = format '%sT%s-0800', date, time
+      during_dst_pst = ::Time.parse(pst_time).in_time_zone(PST).dst?
+
+      pdt_time = format '%%sT%s-0700', date, time
+      during_dst_pdt = ::Time.parse(pdt_time).in_time_zone(PST).dst?
+
+      # If during_dst_pdt is false and during_dst_pst is true, the time does not exist (hour skipped).
+      if !during_dst_pdt && during_dst_pst
+        fail StandardError 'The time specified occurs during a daylight savings time change and does not exist.'
+      end
+
+      # Both are true:
+      #   The time is during DST (during_dst_pdt is true)
+      # Both are false:
+      #   The time is not during DST (during_dst_pdt is false)
+      # during_dst_pdt is true, during_dst_pst if false:
+      #   The time exists twice as it occurs during a shift back to standard time. In that case, assuming the earlier
+      #   point in time (the one during DST) is acceptable.
+      # Therefore, it is safe to return only the value of during_dst_pdt
+      during_dst_pdt
+    end
+  end
+end

--- a/ozone.gemspec
+++ b/ozone.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/spec/ozone_spec.rb
+++ b/spec/ozone_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# rubocop:disable Rails/TimeZone
 module Ozone
   describe Formatter do
     context 'given offset and observes daylight savings boolean' do
@@ -184,7 +185,7 @@ module Ozone
             offset: -480,
             observes_dst: true,
           )
-          expect(ozone_time <=> (1.second.since(time_without_dst))).to eq (-1)
+          expect(ozone_time <=> (1.second.since(time_without_dst))).to eq(-1)
           expect(ozone_time <=> (1.second.until(time_without_dst))).to eq 1
           expect(ozone_time <=> time_without_dst).to eq 0
         end
@@ -196,7 +197,7 @@ module Ozone
             observes_dst: false,
           )
           expect(ozone_time <=> (1.second.until(time_without_dst))).to eq 1
-          expect(ozone_time <=> (1.second.since(time_without_dst))).to eq (-1)
+          expect(ozone_time <=> (1.second.since(time_without_dst))).to eq(-1)
           expect(ozone_time <=> time_without_dst).to eq 0
         end
       end
@@ -211,7 +212,7 @@ module Ozone
             observes_dst: true,
           )
           expect(ozone_time <=> (1.second.until(time_with_dst))).to eq 1
-          expect(ozone_time <=> (1.second.since(time_with_dst))).to eq (-1)
+          expect(ozone_time <=> (1.second.since(time_with_dst))).to eq(-1)
           expect(ozone_time <=> time_with_dst).to eq 0
         end
 
@@ -223,10 +224,11 @@ module Ozone
           )
 
           expect(ozone_time <=> 1.second.until(time_with_dst)).to eq 1
-          expect(ozone_time <=> 1.second.since(time_with_dst)).to eq (-1)
+          expect(ozone_time <=> 1.second.since(time_with_dst)).to eq(-1)
           expect(ozone_time <=> time_with_dst).to eq 0
         end
       end
     end
   end
 end
+# rubocop:enable Rails/TimeZone

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ozone'
+require 'pry'

--- a/spec/time_builder_spec.rb
+++ b/spec/time_builder_spec.rb
@@ -1,0 +1,155 @@
+require 'spec_helper'
+require 'time_builder'
+require 'rspec/core/shared_example_group'
+
+module Ozone
+  describe TimeBuilder do
+    let(:builder) { ::Ozone::TimeBuilder.new }
+
+    context '#build' do
+      let(:from_string) { '2015-11-15 09:00' }
+      let(:with_offset) { -480 } # Pacific offset - Known to observe DST
+      let(:with_dst) { true }
+
+      RSpec.shared_examples 'valid format' do
+        it 'raises no error' do
+          expect do
+            builder.from_string(from_string).with_offset(with_offset).with_dst(with_dst).build
+          end.to_not raise_error
+        end
+      end
+
+      RSpec.shared_examples 'invalid format' do
+        it 'raises an error' do
+          expect do
+            builder.from_string(from_string).with_offset(with_offset).with_dst(with_dst).build
+          end.to raise_error StandardError
+        end
+      end
+
+      RSpec.shared_examples 'an inverse to Ozone::Time' do
+        it 'time == TimeBuilder.from_time(Ozone::Time.new(time).to_s).build' do
+          ozone = ::Ozone::Time.new(time: ::Time.parse(from_string).utc, offset: with_offset, observes_dst: with_dst)
+          time = builder.from_string(ozone.to_s).with_offset(with_offset).with_dst(with_dst).build
+          expect(time).to eq ::Time.parse(from_string).utc
+        end
+
+        it 'time_str == Ozone::Time.new(TimeBuilder.from_time(time_str)).to_s' do
+          time = builder.from_string(from_string).with_offset(with_offset).with_dst(with_dst).build
+          ozone = ::Ozone::Time.new(time: time, offset: with_offset, observes_dst: with_dst)
+          expect(ozone.to_s).to eq from_string
+        end
+      end
+
+      context 'with invalid input' do
+        context 'from_string(nil)' do
+          let(:from_string) { nil }
+          it_behaves_like 'invalid format'
+        end
+
+        context 'from_string(123)' do
+          let(:from_string) { 123 }
+          it_behaves_like 'invalid format'
+        end
+
+        context 'from_string("9:00AM 1/2/2015")' do
+          let(:from_string) { '9:00AM 1/2/2015' }
+          it_behaves_like 'invalid format'
+        end
+
+        context 'with_offset(nil)' do
+          let(:with_offset) { nil }
+          it_behaves_like 'invalid format'
+        end
+
+        context 'with_offset("wat")' do
+          let(:with_offset) { 'wat' }
+          it_behaves_like 'invalid format'
+        end
+
+        context 'with_dst(nil)' do
+          let(:with_dst) { nil }
+          it_behaves_like 'invalid format'
+        end
+      end
+
+      context 'during a time which does not exist' do
+        let(:from_string) { '2015/03/08 02:00' }
+        it 'raises an error' do
+          expect do
+            builder.from_string(from_string).with_offset(with_offset).with_dst(with_dst).build
+          end.to raise_error StandardError
+        end
+      end
+
+      context 'with valid input' do
+        before :each do
+          @time = builder.from_string(from_string).with_offset(with_offset).with_dst(with_dst).build
+        end
+
+        context 'from_string("2015/11/15 09:00")' do
+          let(:from_string) { '2015/11/15 09:00' }
+          it_behaves_like 'valid format'
+        end
+
+        context 'from_string("2015-11-15 09:00")' do
+          let(:from_string) { '2015-11-15 09:00' }
+          it_behaves_like 'valid format'
+        end
+
+        context 'from_string("2015/11/15T09:00")' do
+          let(:from_string) { '2015/11/15T09:00' }
+          it_behaves_like 'valid format'
+        end
+
+        context 'from_string("2015-11-15T09:00")' do
+          let(:from_string) { '2015-11-15T09:00' }
+          it_behaves_like 'valid format'
+        end
+
+        context 'during DST' do
+          let(:from_string) { '2015-04-01 00:00' }
+
+          context 'with_dst(true)' do
+            let(:with_dst) { true }
+            it_behaves_like 'an inverse to Ozone::Time'
+
+            it 'correctly sets UTC time' do
+              expect(@time).to eq ::Time.parse('2015/04/01T07:00+0000').utc
+            end
+          end
+
+          context 'with_dst(false)' do
+            let(:with_dst) { false }
+            it_behaves_like 'an inverse to Ozone::Time'
+
+            it 'correctly sets UTC time' do
+              expect(@time).to eq ::Time.parse('2015/04/01T08:00+0000').utc
+            end
+          end
+        end
+
+        context 'not during DST' do
+          let(:from_string) { '2015-11-15 00:00' }
+          context 'with_dst(true)' do
+            let(:with_dst) { true }
+            it_behaves_like 'an inverse to Ozone::Time'
+
+            it 'correctly sets UTC time' do
+              expect(@time).to eq ::Time.parse('2015/11/15T08:00+0000').utc
+            end
+          end
+
+          context 'with_dst(false)' do
+            let(:with_dst) { false }
+            it_behaves_like 'an inverse to Ozone::Time'
+
+            it 'correctly sets UTC time' do
+              expect(@time).to eq ::Time.parse('2015/11/15T08:00+0000').utc
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The purpose is to be able to take a string like "2015/11/01 09:00" and turn that into the correct UTC time based on an offset and whether or not dst is observed. The function should be exactly the inverse of Ozone::Time. 

This change is in support of https://jira.practicefusion.com/browse/CON-5279

